### PR TITLE
Fix formatting warning of ln_ on MSVC and on 32-bit builds.

### DIFF
--- a/ini.hpp
+++ b/ini.hpp
@@ -33,6 +33,7 @@
 #include <cstring>
 #include <iostream>
 #include <fstream>
+#include <sstream>
 
 namespace INI {
 
@@ -81,9 +82,9 @@ private:
 inline void
 Parser::err(const char* s)
 {
-  char buf[256];
-  sprintf(buf, "%s on line #%ld", s, ln_);
-  throw std::runtime_error(buf);
+  std::ostringstream os;
+  os << s << " on line #" << ln_;
+  throw std::runtime_error(os.str());
 }
 
 inline std::string trim(const std::string& s)


### PR DESCRIPTION
When compiling ini.hpp with MSVC (any architecture) or with GCC (32 bit, i.e. with -m32), a warning is triggered about the line:

```
sprintf(buf, "%s on line #%ld", s, ln_);
```

The problem is that the %ld format specifier may have the wrong length on 32-bit architectures, and that size_t isn't considered equivalent to unsigned long on MSVC. The attached patch fixes this problem by using the standard ostringstream formatting features. (Another fix would be to use %zu on GCC and %Iu on MSVC/MINGW; see http://stackoverflow.com/q/1546789 for more discussion about this.)